### PR TITLE
Added test support to the setup entrypoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,8 @@ setup(name='clastic',
       install_requires=['Werkzeug==0.9.4', 'argparse>=1.2.1'],
       license=__license__,
       platforms='any',
+      test_suite='nose.collector',
+      tests_require=['Mako>=1.0.0', 'nose>=1.3.7'],
       classifiers=[
           'Intended Audience :: Developers',
           'Topic :: Internet :: WWW/HTTP :: HTTP Servers',


### PR DESCRIPTION
- Based on [nose documentation](http://nose.readthedocs.org/en/latest/setuptools_integration.html)
- Added required packages (not already collected as part of `install_requires`) to `tests_require`
- Executed in a Python 2.7.9 environment where `python -c 'import setuptools;print setuptools.__version__'` reports `11.0`
- Ran 248 tests successfully in 0.832s