### PR TITLE
BoundRoutes refactor

### DIFF
--- a/.tox-coveragerc
+++ b/.tox-coveragerc
@@ -5,7 +5,7 @@ source =
     ../clastic
 omit =
      */_werkzeug_serving.py*
-     */flycheck__*
+     */flycheck_*
 
 [paths]
 source =

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ init:
 
 install:
   - "%PYTHON%/Scripts/easy_install -U pip"
-  - "%PYTHON%/Scripts/pip install tox wheel"
+  - "%PYTHON%/Scripts/pip install -U --force-reinstall tox wheel"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/clastic/application.py
+++ b/clastic/application.py
@@ -133,6 +133,13 @@ class Application(object):
         for rt in self.routes:
             yield rt
 
+    def __repr__(self):
+        cn = self.__class__.__name__
+        ret = ('<%s routes_count=%s resources_keys=%r middlewares=%r render_factory=%r slash_mode=%r debug=%r>'
+               % (cn, len(self.routes), list(self.resources.keys()), self.middlewares,
+                  self.render_factory, self.slash_mode, self.debug))
+        return ret
+
     def add(self, entry, index=None, **kwargs):
         if index is None:
             index = len(self.routes)

--- a/clastic/application.py
+++ b/clastic/application.py
@@ -25,7 +25,7 @@ from .errors import (HTTPException,
                      MIME_SUPPORT_MAP,
                      ErrorHandler,
                      ContextualErrorHandler)
-from .sinter import get_arg_names
+from .sinter import get_arg_names, inject
 
 
 try:
@@ -206,6 +206,7 @@ class Application(object):
                         dispatch_state.add_exception(nf_exc)
                         continue
             try:
+                print(params)
                 ret = route.execute(**params)
                 if not isinstance(ret, BaseResponse):
                     msg = 'expected Response, received %r' % type(ret)
@@ -228,7 +229,7 @@ class Application(object):
         if isinstance(ret, HTTPException):
             error_params = dict(params, _error=ret)
             try:
-                ret = ret.source_route.render_error(**error_params)
+                ret = ret.source_route.execute_error(**error_params)
             except Exception:
                 ret = default_render_error(**error_params)
         return ret

--- a/clastic/application.py
+++ b/clastic/application.py
@@ -206,7 +206,6 @@ class Application(object):
                         dispatch_state.add_exception(nf_exc)
                         continue
             try:
-                print(params)
                 ret = route.execute(**params)
                 if not isinstance(ret, BaseResponse):
                     msg = 'expected Response, received %r' % type(ret)

--- a/clastic/application.py
+++ b/clastic/application.py
@@ -12,7 +12,6 @@ from werkzeug.wrappers import Request, Response, BaseResponse
 
 from .server import run_simple
 from .route import (Route,
-                    BaseRoute,
                     NullRoute,
                     S_STRICT,
                     S_REDIRECT,
@@ -40,7 +39,7 @@ _REQ_ID_ITER = itertools.count()
 
 
 def cast_to_route_factory(in_arg):
-    if isinstance(in_arg, (BaseRoute, SubApplication)):
+    if isinstance(in_arg, (Route, SubApplication)):
         return in_arg
     elif isinstance(in_arg, Sequence):
         try:

--- a/clastic/application.py
+++ b/clastic/application.py
@@ -139,7 +139,7 @@ class Application(object):
         rf = cast_to_route_factory(entry)
 
         kwargs.setdefault('rebind_render', getattr(rf, 'rebind_render', True))
-        kwargs.setdefault('inherit_slashes', getattr(rf, 'rebind_render', True))
+        kwargs.setdefault('inherit_slashes', getattr(rf, 'inherit_slashes', True))
 
         if callable(getattr(rf, 'bind_all', None)):
             bound_routes = rf.bind_all(self, **kwargs)

--- a/clastic/errors.py
+++ b/clastic/errors.py
@@ -498,7 +498,7 @@ class ErrorHandler(object):
         """
         self.reraise_uncaught = kwargs.get('reraise_uncaught')
 
-    def render_error(self, request, _error, **kwargs):
+    def render_error(self, request, _error):
         best_match = request.accept_mimetypes.best_match(MIME_SUPPORT_MAP)
         _error.adapt(best_match)
         return _error

--- a/clastic/meta.py
+++ b/clastic/meta.py
@@ -195,7 +195,7 @@ def get_pyvm_info():
     ret['have_ucs4'] = getattr(sys, 'maxunicode', 0) > 65536
     ret['have_readline'] = HAVE_READLINE
 
-    ret['active_thread_count'] = glom(sys, T._current_frames().__len__(), skip_exc=Exception)
+    ret['active_thread_count'] = glom(sys, (T._current_frames(), len), skip_exc=Exception)
     ret['recursion_limit'] = sys.getrecursionlimit()
 
     ret['gc'] = glom(None, Call(get_gc_info), skip_exc=Exception)  # effectively try/except:pass
@@ -210,7 +210,7 @@ def get_gc_info():
     ret['thresholds'] = gc.get_threshold()
 
     ret['counts'] = glom(gc, T.get_count(), skip_exc=Exception)
-    ret['obj_count'] = glom(gc, T.get_objects().__len__(), skip_exc=Exception)
+    ret['obj_count'] = glom(gc, (T.get_objects(), len), skip_exc=Exception)
 
     return ret
 
@@ -242,7 +242,7 @@ def get_endpoint_info(route):
     try:
         ret['name'] = route.endpoint.func_name
         ret['module_name'] = route.endpoint.__module__
-    except:
+    except AttributeError:
         ret['name'] = repr(route.endpoint)
     return ret
 
@@ -250,8 +250,8 @@ def get_endpoint_info(route):
 def get_render_info(route):
     ret = {'type': None}
     render_arg = route.render_arg
-    if route._render_factory and not callable(render_arg):
-        ret['type'] = route._render_factory.__class__.__name__
+    if route.render_factory and not callable(render_arg):
+        ret['type'] = route.render_factory.__class__.__name__
         ret['arg'] = render_arg
     elif render_arg is None:
         ret['arg'] = None

--- a/clastic/meta.py
+++ b/clastic/meta.py
@@ -275,10 +275,10 @@ def get_route_arg_info(route):
             source = 'builtin'
         elif arg in route.path_args:
             source = 'url'
-        elif arg in route._resources:
+        elif arg in route.resources:
             source = 'resources'
         else:
-            for mw in route._middlewares:
+            for mw in route.middlewares:
                 if arg in mw.provides:
                     source = 'middleware'
                     break

--- a/clastic/route.py
+++ b/clastic/route.py
@@ -437,16 +437,6 @@ class Route(object):
     def iter_routes(self):
         yield self
 
-    def empty(self):  # TODO
-        ret = type(self)(pattern=self.pattern,
-                         endpoint=self.endpoint,
-                         render=self.render,
-                         render_error=self.render_error,
-                         resources=self.resources,
-                         slash_mode=self.slash_mode,
-                         methods=self.methods)
-        return ret
-
     def bind(self, app, **kwargs):
         return BoundRoute(self, app, **kwargs)
 
@@ -455,7 +445,7 @@ class Route(object):
         ep = self.endpoint
         try:
             ep_name = '%s.%s' % (ep.__module__, ep.func_name)
-        except:
+        except Exception:
             ep_name = repr(ep)
         args = (cn, self.pattern, ep_name)
         tmpl = '<%s pattern=%r endpoint=%s>'

--- a/clastic/route.py
+++ b/clastic/route.py
@@ -194,53 +194,79 @@ def check_render_error(render_error, resources):
     return True
 
 
-class Route(object):
-    def __init__(self, pattern, endpoint, render=None,
-                 render_error=None, **kwargs):
-        self._middlewares = list(kwargs.pop('middlewares', []))
-        self._resources = dict(kwargs.pop('resources', []))
+class BoundRoute(object):
+    def __init__(self, route, app, **kwargs):
+        # keep a reference to the unbound version
+        self.unbound_route = unbound_route = getattr(route, 'unbound_route', route)
+        self.bound_apps = getattr(route, 'bound_apps', []) + [app]
 
-        self.slash_mode = kwargs.pop('slash_mode', S_REDIRECT)
-        methods = kwargs.pop('methods', None)
-        self.methods = methods and set([m.upper() for m in methods])
+        prefix = kwargs.pop('prefix', '')
+        rebind_render = kwargs.pop('rebind_render', True)
+        inherit_slashes = kwargs.pop('inherit_slashes', True)
+        rebind_render_error = kwargs.pop('rebind_render_error', True)
         if kwargs:
             raise TypeError('unexpected keyword args: %r' % kwargs.keys())
-        self.pattern = pattern
-        self.endpoint = endpoint
-        self._execute = endpoint
-        self._compile()
 
-        self._bound_apps = []
-        self.endpoint_args = get_arg_names(endpoint)
+        self.pattern = prefix + route.pattern
+        self.slash_mode = app.slash_mode if inherit_slashes else route.slash_mode
+        self.methods = route.methods
 
-        self._render = None
-        self._render_factory = None
-        self.render_arg = render
-        if callable(self.render_arg):
-            self._render = self.render_arg
-        self._render_error = render_error
-        self._required_args = self._resolve_required_args()
-
-    def _compile(self):
-        # maybe: if not getattr(self, 'regex', None) or \
-        #          self.regex.pattern != self.pattern:
         self.regex, self.converters = _compile_path_pattern(self.pattern,
                                                             self.slash_mode)
         self.path_args = self.converters.keys()
-        if self.methods:
-            unknown_methods = list(self.methods - HTTP_METHODS)
-            if unknown_methods:
-                raise InvalidMethod('unrecognized HTTP method(s): %r'
-                                    % unknown_methods)
-            if 'GET' in self.methods:
-                self.methods.add('HEAD')
+        self.endpoint_args = get_arg_names(unbound_route.endpoint)
+
+        app_resources = getattr(app, 'resources', {})
+        self.resources = dict(app_resources)
+        self.resources.update(getattr(route, 'resources', {}))
+        app_mws = getattr(app, 'middlewares', [])
+        self.middlewares = tuple(merge_middlewares(getattr(route, 'middlewares', []), app_mws))
+
+        # rebind_render is basically a way of making the generated
+        # render function sticky to the first application which can
+        # fulfill it. but it might mean rebinding bound routes or
+        # something.
+        self._render_factory = app.render_factory if rebind_render else getattr(route, '_render_factory', None)
+
+        if callable(unbound_route.render):  # TODO rebind?
+            render = unbound_route.render
+        elif callable(app.render_factory) and unbound_route.render is not None:
+            render = app.render_factory(route.render)
+        else:
+            render = _noop_render
+        self._render = render
+
+        if rebind_render_error:
+            render_error = getattr(app.error_handler, 'render_error', None)
+        else:
+            render_error = unbound_route.render_error
+        if callable(render_error):
+            check_render_error(render_error, self.resources)
+        self._render_error = render_error
+
+        src_provides_map = {'url': set(self.converters),
+                            'builtins': set(RESERVED_ARGS),
+                            'resources': set(self.resources)}
+        check_middlewares(self.middlewares, src_provides_map)
+        provided = set.union(*src_provides_map.values())
+
+        self._execute = make_middleware_chain(self.middlewares, unbound_route.endpoint, render, provided)
+
+        self._required_args = self._resolve_required_args()
+
+    def bind(self, app, **kwargs):
+        return BoundRoute(self, app, **kwargs)
+
+    def iter_routes(self):
+        yield self  # .route  # yield the unbound route?
+
+    @property
+    def endpoint(self):
+        return self.unbound_route.endpoint
 
     @property
     def is_branch(self):
-        return self.pattern.endswith('/')
-
-    def iter_routes(self):
-        yield self
+        return self.unbound_route.is_branch
 
     def match_path(self, path):
         ret = {}
@@ -260,108 +286,6 @@ class Route(object):
             if method.upper() not in self.methods:
                 return False
         return True
-
-    def execute(self, request, **kwargs):
-        injectables = {'_route': self,
-                       'request': request,
-                       '_application': self._bound_apps[-1] if self._bound_apps else None}
-        injectables.update(self._resources)
-        injectables.update(kwargs)
-        return inject(self._execute, injectables)
-
-    def render_error(self, request, _error, **kwargs):
-        if not callable(self._render_error):
-            raise TypeError('render_error not set or not callable')
-        injectables = {'_route': self,
-                       '_error': _error,
-                       'request': request,
-                       '_application': self._bound_apps[-1]}
-        injectables.update(self._resources)
-        injectables.update(kwargs)
-        return inject(self._render_error, injectables)
-
-    def empty(self):
-        # more like a copy
-        self_type = type(self)
-        ret = self_type(self.pattern, self.endpoint, self.render_arg)
-        ret.__dict__.update(self.__dict__)
-        ret._middlewares = list(self._middlewares)
-        ret._resources = dict(self._resources)
-        ret._bound_apps = list(self._bound_apps)
-        return ret
-
-    def bind(self, app, **kwargs):
-        rebind_render = kwargs.pop('rebind_render', True)
-        inherit_slashes = kwargs.pop('inherit_slashes', True)
-        rebind_render_error = kwargs.pop('rebind_render_error', True)
-        if kwargs:
-            raise TypeError('unexpected keyword args: %r' % kwargs.keys())
-
-        resources = getattr(app, 'resources', {})
-        middlewares = getattr(app, 'middlewares', [])
-        if rebind_render:
-            render_factory = getattr(app, 'render_factory', None)
-        else:
-            render_factory = self._render_factory
-        if rebind_render_error:
-            render_error = getattr(app.error_handler, 'render_error', None)
-        else:
-            render_error = self._render_error
-
-        merged_mw = merge_middlewares(self._middlewares, middlewares)
-
-        params = {'app': app,
-                  'resources': dict(self._resources, **resources),
-                  'middlewares': merged_mw,
-                  'render_factory': render_factory,
-                  'render_error': render_error}
-
-        # test a copy of the route before making any changes, for extra safety
-        r_copy = self.empty()
-        if inherit_slashes:
-            r_copy.slash_mode = app.slash_mode
-        r_copy._bind_args(**params)
-        r_copy._compile()
-        # if none of the above raised an exception, we're golden
-
-        if inherit_slashes:
-            self.slash_mode = app.slash_mode
-        self._bind_args(**params)
-        self._compile()
-        self._bound_apps += (app,)
-        return self
-
-    def _bind_args(self, app, resources, middlewares,
-                   render_factory, render_error):
-        url_args = set(self.converters.keys())
-        builtin_args = set(RESERVED_ARGS)
-        resource_args = set(resources.keys())
-
-        tmp_avail_args = {'url': url_args,
-                          'builtins': builtin_args,
-                          'resources': resource_args}
-        check_middlewares(middlewares, tmp_avail_args)
-        provided = resource_args | builtin_args | url_args
-        if callable(render_factory) and self.render_arg is not None \
-                and not callable(self.render_arg):
-            _render = render_factory(self.render_arg)
-        elif callable(self._render):
-            _render = self._render
-        else:
-            _render = _noop_render
-        _execute = make_middleware_chain(middlewares, self.endpoint, _render, provided)
-
-        if callable(render_error):
-            check_render_error(render_error, resources)
-
-        self._resources.update(resources)
-        self._middlewares = middlewares
-        self._render_factory = render_factory
-        self._render = _render
-        self._render_error = render_error
-        self._execute = _execute
-
-        self._required_args = self._resolve_required_args()
 
     def _resolve_required_args(self, with_builtins=False):
         """Creates a list of fully resolved endpoint requirements, working
@@ -400,14 +324,14 @@ class Route(object):
         url_args = self.converters.keys()
         add(url_args)
         add(RESERVED_ARGS)
-        add(self._resources.keys())
+        add(self.resources.keys())
 
-        for mw in self._middlewares:
+        for mw in self.middlewares:
             add_func(mw.provides, mw.request)
             add_func(mw.endpoint_provides, mw.endpoint)
             add_func(mw.render_provides, mw.render)
 
-        add_func(['__endpoint_response__'], self.endpoint)
+        add_func(['__endpoint_response__'], self.unbound_route.endpoint)
 
         resolved = resolve_deps(args)
 
@@ -423,6 +347,25 @@ class Route(object):
     def is_required_arg(self, arg_name):
         return arg_name in self._required_args
 
+    def execute(self, request, **kwargs):
+        injectables = {'_route': self,
+                       'request': request,
+                       '_application': self.bound_apps[-1]}
+        injectables.update(self.resources)
+        injectables.update(kwargs)
+        return inject(self._execute, injectables)  # TODO
+
+    def render_error(self, request, _error, **kwargs):
+        if not callable(self._render_error):
+            raise TypeError('render_error not set or not callable')
+        injectables = {'_route': self,
+                       '_error': _error,
+                       'request': request,
+                       '_application': self.bound_apps[-1]}
+        injectables.update(self.resources)  # TODO
+        injectables.update(kwargs)
+        return inject(self._render_error, injectables)
+
     def get_info(self):
         ret = {}
         route = self
@@ -432,7 +375,7 @@ class Route(object):
         ret['endpoint'] = route.endpoint
         ret['endpoint_args'] = ep_fb.args
         ret['endpoint_defaults'] = ep_defaults
-        ret['render_arg'] = route.render_arg
+        ret['render_arg'] = route.unbound_route.render
         srcs = {}
         for arg in route.endpoint_args:
             if arg in RESERVED_ARGS:
@@ -441,14 +384,71 @@ class Route(object):
                 srcs[arg] = 'url'
             elif arg in ep_defaults:
                 srcs[arg] = 'default'
-            for mw in route._middlewares:
+            for mw in route.middlewares:
                 if arg in mw.provides:
                     srcs[arg] = mw
-            if arg in route._resources:
+            if arg in route.resources:
                 srcs[arg] = 'resources'
             # TODO: trace to application if middleware/resource
         ret['sources'] = srcs
         return ret
+
+    def __repr__(self):
+        cn = self.__class__.__name__
+        return '<%s route=%r bound_app=%r>' % (cn, self.unbound_route, self.bound_apps[-1])
+
+
+class Route(object):
+    def __init__(self, pattern, endpoint, render=None,
+                 render_error=None, **kwargs):
+        self.middlewares = list(kwargs.pop('middlewares', []))
+        self.resources = dict(kwargs.pop('resources', []))
+
+        self.slash_mode = kwargs.pop('slash_mode', S_REDIRECT)
+        methods = kwargs.pop('methods', None)
+
+        if kwargs:
+            raise TypeError('unexpected keyword args: %r' % kwargs.keys())
+
+        self.methods = methods and set([m.upper() for m in methods])
+        if self.methods:
+            unknown_methods = list(self.methods - HTTP_METHODS)
+            if unknown_methods:
+                raise InvalidMethod('unrecognized HTTP method(s): %r'
+                                    % unknown_methods)
+            if 'GET' in self.methods:
+                self.methods.add('HEAD')
+
+        _compile_path_pattern(pattern, self.slash_mode)  # checking pattern
+        self.pattern = pattern
+
+        if not callable(endpoint):
+            raise TypeError('expected endpoint to be a function or method, not: %r' % endpoint)
+        self.endpoint = endpoint
+        self.render_error = render_error
+        if callable(render_error):
+            check_render_error(render_error, self.resources)
+        self.render = render
+
+    @property
+    def is_branch(self):
+        return self.pattern.endswith('/')
+
+    def iter_routes(self):
+        yield self
+
+    def empty(self):  # TODO
+        ret = type(self)(pattern=self.pattern,
+                         endpoint=self.endpoint,
+                         render=self.render,
+                         render_error=self.render_error,
+                         resources=self.resources,
+                         slash_mode=self.slash_mode,
+                         methods=self.methods)
+        return ret
+
+    def bind(self, app, **kwargs):
+        return BoundRoute(self, app, **kwargs)
 
     def __repr__(self):
         cn = self.__class__.__name__
@@ -487,7 +487,7 @@ class NullRoute(Route):
 
     def bind(self, *a, **kw):
         kw['inherit_slashes'] = False
-        super(NullRoute, self).bind(*a, **kw)
+        return super(NullRoute, self).bind(*a, **kw)
 
 
 def toposort(dep_map):

--- a/clastic/sinter.py
+++ b/clastic/sinter.py
@@ -45,7 +45,7 @@ def get_arg_names(f, only_required=False):
 
 
 def inject(f, injectables):
-    __traceback_hide__ = True  # TODO
+    __traceback_hide__ = True
 
     fb = get_fb(f)
 

--- a/clastic/tests/test_arg_resolve.py
+++ b/clastic/tests/test_arg_resolve.py
@@ -92,8 +92,8 @@ def test_resolution_basic():
         return {}
 
     route = Route('/<url_arg>/', endpoint_func, middlewares=mws)
-
-    assert route.is_required_arg('a') is True
+    bound_route = route.bind(Application())
+    assert bound_route.is_required_arg('a') is True
 
 
 ### BASIC END
@@ -105,7 +105,7 @@ def test_resolution_null():
         pass
 
     route = Route('/', endpoint_func)
-
-    assert len(route.get_required_args()) == 0
+    bound_route = route.bind(Application())
+    assert len(bound_route.get_required_args()) == 0
 
 ### NULL END

--- a/clastic/tests/test_ashes_render.py
+++ b/clastic/tests/test_ashes_render.py
@@ -29,6 +29,23 @@ def test_ashes():
     assert resp.status_code, 200
     assert b'Rajkumar' in resp.data
 
+    # test rebind
+
+    # no loss of binding on applications with no render factory
+    wrap_app = Application([('/', app)])
+    assert wrap_app.routes[0].render_factory is ashes_render
+    c = wrap_app.get_local_client()
+    resp = c.get('/')
+    assert resp.status_code == 200
+    assert b'<html>' in resp.data
+    assert b'world' in resp.data
+
+    # test bind new but not old
+    ashes_render2 = AshesRenderFactory(_TMPL_DIR)
+    wrap_app2 = Application([('/test', hello_world_ctx, tmpl),
+                             ('/', app)], render_factory=ashes_render2)
+    assert wrap_app2.routes[0].render_factory is ashes_render2
+    assert wrap_app2.routes[1].render_factory is ashes_render
 
 def test_ashes_missing_template():
     ashes_render = AshesRenderFactory(_TMPL_DIR)

--- a/clastic/tests/test_ashes_render.py
+++ b/clastic/tests/test_ashes_render.py
@@ -47,6 +47,7 @@ def test_ashes():
     assert wrap_app2.routes[0].render_factory is ashes_render2
     assert wrap_app2.routes[1].render_factory is ashes_render
 
+
 def test_ashes_missing_template():
     ashes_render = AshesRenderFactory(_TMPL_DIR)
     tmpl = 'missing_template.html'

--- a/clastic/tests/test_basic.py
+++ b/clastic/tests/test_basic.py
@@ -27,6 +27,7 @@ def test_single_mw_basic():
     app = Application([('/', hello_world)],
                       resources={},
                       middlewares=[dumdum])
+    assert repr(app)
     assert dumdum in app.middlewares
     assert dumdum in app.routes[0].middlewares
 

--- a/clastic/tests/test_basic.py
+++ b/clastic/tests/test_basic.py
@@ -19,7 +19,7 @@ def test_create_hw_application():
     app = Application([route])
     assert app.routes
     assert callable(app.routes[0]._execute)
-    assert app.routes[0]._bound_apps[0] is app
+    assert app.routes[0].bound_apps[-1] is app
 
 
 def test_single_mw_basic():
@@ -28,7 +28,7 @@ def test_single_mw_basic():
                       resources={},
                       middlewares=[dumdum])
     assert dumdum in app.middlewares
-    assert dumdum in app.routes[0]._middlewares
+    assert dumdum in app.routes[0].middlewares
 
     resp = app.get_local_client().get('/')
     assert resp.status_code == 200
@@ -40,7 +40,7 @@ def test_duplicate_noarg_mw():
         app = Application([('/', hello_world)],
                           middlewares=mw)
         assert app
-        assert len(app.routes[0]._middlewares) == mw_count
+        assert len(app.routes[0].middlewares) == mw_count
 
         resp = app.get_local_client().get('/')
         assert resp.status_code == 200
@@ -90,7 +90,7 @@ def test_subapplication_basic():
     assert check_patts(merged_name_app_patts, name_app_patts)
 
     assert len(set([r.pattern for r in app.routes])) == 3
-    assert len(app.routes[0]._middlewares) == 1  # middleware merging
+    assert len(app.routes[0].middlewares) == 1  # middleware merging
 
     resp = no_name_app.get_local_client().get('/')
     assert resp.data == b'Hello, world!'

--- a/clastic/tests/test_render.py
+++ b/clastic/tests/test_render.py
@@ -29,7 +29,7 @@ def test_json_render(render_json=None):
                        ('/beta/<name>/', complex_context, render_json)])
 
     assert callable(app.routes[0]._execute)
-    assert callable(app.routes[0]._render)
+    assert callable(app.routes[0].render)
     c = app.get_local_client()
 
     resp = c.get('/')
@@ -78,7 +78,7 @@ def test_default_render():
                        ('/beta/<name>/', complex_context, render_basic)])
 
     assert callable(app.routes[0]._execute)
-    assert callable(app.routes[0]._render)
+    assert callable(app.routes[0].render)
     c = app.get_local_client()
 
     resp = c.get('/')  # test simple json with endpoint default

--- a/clastic/tests/test_render_error.py
+++ b/clastic/tests/test_render_error.py
@@ -16,10 +16,8 @@ def odd_endpoint(number):
 def test_app_error_render():
 
     rt = Route('/<number:int>', odd_endpoint, render_basic)
-    assert rt._render_error is None
 
     app = Application([rt])
-    # assert rt._render_error is render_error_basic
 
     cl = app.get_local_client()
     assert cl.get('/1').status_code == 200

--- a/clastic/tests/test_render_error.py
+++ b/clastic/tests/test_render_error.py
@@ -84,8 +84,6 @@ def test_error_render_count():
     assert len(error_list) == 1
 
     err_resp = cl.get('/6/badgateway')
-    #if err_resp.status_code != 502:
-    #    import pdb;pdb.set_trace()
     assert err_resp.status_code == 502
     assert len(error_list) == 2
 

--- a/clastic/tests/test_routing.py
+++ b/clastic/tests/test_routing.py
@@ -6,7 +6,7 @@ from pytest import raises
 from clastic import Application, render_basic, Response
 from clastic.application import Application
 
-from clastic.route import BaseRoute, Route
+from clastic.route import Route
 from clastic.route import (InvalidEndpoint,
                            InvalidPattern,
                            InvalidMethod)
@@ -20,7 +20,7 @@ NO_OP = lambda: Response()
 
 def test_new_base_route():
     # note default slashing behavior
-    rp = BaseRoute('/a/b/<t:int>/thing/<das+int>')
+    rp = Route('/a/b/<t:int>/thing/<das+int>', NO_OP)
     d = rp.match_path('/a/b/1/thing/1/2/3/4')
     assert d == {u't': 1, u'das': [1, 2, 3, 4]}
 
@@ -30,24 +30,19 @@ def test_new_base_route():
     d = rp.match_path('/a/b/1/thing/')
     assert d == None
 
-    rp = BaseRoute('/a/b/<t:int>/thing/<das*int>', methods=['GET'])
+    rp = Route('/a/b/<t:int>/thing/<das*int>', NO_OP, methods=['GET'])
     d = rp.match_path('/a/b/1/thing')
     assert d == {u't': 1, u'das': []}
 
 
 def test_base_route_executes():
-    br = BaseRoute('/', lambda request: request['stephen'])
+    br = Route('/', lambda request: request['stephen'])
     res = br.execute({'stephen': 'laporte'})
     assert res == 'laporte'
 
 
-def test_base_route_raises_on_no_ep():
-    with raises(InvalidEndpoint):
-        BaseRoute('/a/b/<t:int>/thing/<das+int>').execute({})
-
-
 def test_base_application_basics():
-    br = BaseRoute('/', lambda request: Response('lolporte'))
+    br = Route('/', lambda request: Response('lolporte'))
     ba = Application([br])
     client = ba.get_local_client()
     res = client.get('/')

--- a/clastic/tests/test_routing.py
+++ b/clastic/tests/test_routing.py
@@ -97,7 +97,8 @@ def test_create_route_order_incr():
     client = app.get_local_client()
     for r in routes:
         app.add(r)
-        assert client.get('/api/a').data == b'api: a/b'
+        assert client.get('/api/a').data == b'api: a'
+        assert client.get('/api/a/b/').data == b'api: a/b'
         assert app.routes[-1].get_info()['url_pattern'] == r[0]
     return
 

--- a/clastic/tests/test_routing.py
+++ b/clastic/tests/test_routing.py
@@ -99,7 +99,6 @@ def test_create_route_order_incr():
         app.add(r)
         assert client.get('/api/a').data == b'api: a'
         assert client.get('/api/a/b/').data == b'api: a/b'
-        assert app.routes[-1].get_info()['url_pattern'] == r[0]
     return
 
 

--- a/clastic/tests/test_routing.py
+++ b/clastic/tests/test_routing.py
@@ -20,7 +20,8 @@ NO_OP = lambda: Response()
 
 def test_new_base_route():
     # note default slashing behavior
-    rp = Route('/a/b/<t:int>/thing/<das+int>', NO_OP)
+    ub_rp = Route('/a/b/<t:int>/thing/<das+int>', NO_OP)
+    rp = ub_rp.bind(Application())
     d = rp.match_path('/a/b/1/thing/1/2/3/4')
     assert d == {u't': 1, u'das': [1, 2, 3, 4]}
 
@@ -30,13 +31,14 @@ def test_new_base_route():
     d = rp.match_path('/a/b/1/thing/')
     assert d == None
 
-    rp = Route('/a/b/<t:int>/thing/<das*int>', NO_OP, methods=['GET'])
+    ub_rp = Route('/a/b/<t:int>/thing/<das*int>', NO_OP, methods=['GET'])
+    rp = ub_rp.bind(Application())
     d = rp.match_path('/a/b/1/thing')
     assert d == {u't': 1, u'das': []}
 
 
 def test_base_route_executes():
-    br = Route('/', lambda request: request['stephen'])
+    br = Route('/', lambda request: request['stephen']).bind(Application())
     res = br.execute({'stephen': 'laporte'})
     assert res == 'laporte'
 
@@ -95,7 +97,7 @@ def test_create_route_order_incr():
     client = app.get_local_client()
     for r in routes:
         app.add(r)
-        assert client.get('/api/a/b').data == b'api: a/b'
+        assert client.get('/api/a').data == b'api: a/b'
         assert app.routes[-1].get_info()['url_pattern'] == r[0]
     return
 


### PR DESCRIPTION
Old-school clastic mutates Route in place. This new way cleans things up and provides a "copy on bind" approach, by splitting Route and BoundRoute. The BoundRoute constructor is where all the magic happens now.