### PR TITLE
Semantic fix in tzconvert example

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -544,7 +544,8 @@ And the home page template becomes:
      <title>Time zone convertor</title>
      <link rel="stylesheet" href="/static/custom.css">
      <script>
-       async function showResult() {
+       async function showResult(event) {
+         event.preventDefault();
          let formData = new FormData(document.querySelector('form'));
          let response = await fetch('/show', {
            method: 'POST',
@@ -593,8 +594,9 @@ And the home page template becomes:
            </select>
          </div>
        </div>
+
+       <button onclick="showResult(event)">Show</button></p>
      </form>
-     <p><button onclick="showResult()">Show</button></p>
 
      <p class="info">
        When it's <time id="src_dt" datetime="2020-01-01T18:00">Jan 1 2020</time>
@@ -613,9 +615,6 @@ The changes are:
 
 - The JavaScript code for updating the page is added.
   It gets called when the button is clicked.
-
-- The button element is moved out of the form element.
-  Also, the form action now points to the current URL.
 
 One last thing to do is to hide the result markup
 before the user clicks the "Show" button.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -595,7 +595,7 @@ And the home page template becomes:
          </div>
        </div>
 
-       <button onclick="showResult(event)">Show</button></p>
+       <button onclick="showResult(event)">Show</button>
      </form>
 
      <p class="info">

--- a/examples/tzconvert/home.html
+++ b/examples/tzconvert/home.html
@@ -5,7 +5,8 @@
   <title>Time zone convertor</title>
   <link rel="stylesheet" href="/static/custom.css">
   <script>
-    async function showResult() {
+    async function showResult(event) {
+      event.preventDefault();
       let formData = new FormData(document.querySelector('form'));
       let response = await fetch('/show', {
         method: 'POST',
@@ -54,8 +55,9 @@
         </select>
       </div>
     </div>
+
+    <button onclick="showResult(event)">Show</button>
   </form>
-  <p><button onclick="showResult()">Show</button></p>
 
   <p class="info">
     When it's <time id="src_dt" datetime="2020-01-01T18:00">Jan 1 2020</time>


### PR DESCRIPTION
I think this is the proper way of handling the form button at the JSON section of the tutorial example. Instead of moving the button element out of the form (which is semantically incorrect, I believe), we prevent the standard form submission event.