### PR TITLE
Add python 3.10 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,20 @@
 # This configuration based on:
 # https://github.com/audreyr/cookiecutter/commit/3c4685f536afda3be93da3fe3039cec0ab0d60a3
 
+# By default appveyor runs on Visual Studio 2015
+# https://www.appveyor.com/docs/build-environment/#choosing-image-for-your-builds
+image: Visual Studio 2019
+
 environment:
   matrix:
     - PYTHON: "C:\\Python37-x64"
       TOX_ENV: "py37"
+    - PYTHON: "C:\\Python38-x64"
+      TOX_ENV: "py38"
+    - PYTHON: "C:\\Python39-x64"
+      TOX_ENV: "py39"
+    - PYTHON: "C:\\Python310-x64"
+      TOX_ENV: "py310"
 
 
 init:
@@ -17,7 +27,6 @@ init:
   - "%PYTHON%/python -c \"import struct;print(8 * struct.calcsize(\'P\'))\""
 
 install:
-  - "%PYTHON%/Scripts/easy_install -U pip"
   - "%PYTHON%/Scripts/pip install -U --force-reinstall tox wheel"
 
 build: false  # Not a C# project, build stuff at the test step instead.

--- a/clastic/application.py
+++ b/clastic/application.py
@@ -3,7 +3,11 @@ from __future__ import unicode_literals
 
 import os
 import itertools
-from collections import Sequence
+import sys
+if sys.version_info < (3,3,):
+    from collections import Sequence
+else:
+    from collections.abc import Sequence
 from argparse import ArgumentParser
 
 import attr

--- a/clastic/middleware/context.py
+++ b/clastic/middleware/context.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from collections import Mapping
+import sys
+if sys.version_info < (3,3,):
+    from collections import Mapping
+else:
+    from collections.abc import Mapping
 
 from ..sinter import FunctionBuilder
 from .core import Middleware

--- a/clastic/middleware/form.py
+++ b/clastic/middleware/form.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from collections import Mapping, Iterable
+import sys
+if sys.version_info < (3,3,):
+    from collections import Mapping, Iterable
+else:
+    from collections.abc import Mapping, Iterable
 
 from boltons.iterutils import is_iterable
 

--- a/clastic/middleware/url.py
+++ b/clastic/middleware/url.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from collections import Mapping, Iterable
+import sys
+if sys.version_info < (3,3,):
+    from collections import Mapping, Iterable
+else:
+    from collections.abc import Mapping, Iterable
 
 from boltons.iterutils import is_iterable
 

--- a/clastic/render/simple.py
+++ b/clastic/render/simple.py
@@ -3,7 +3,11 @@
 import sys
 import itertools
 from json import JSONEncoder
-from collections import Mapping, Sized, Iterable
+import sys
+if sys.version_info < (3,3,):
+    from collections import Mapping, Sized, Iterable
+else:
+    from collections.abc import Mapping, Sized, Iterable
 
 from werkzeug.wrappers import Response
 


### PR DESCRIPTION
Hi @mahmoud,

This `PR` adds support for `python` **3.10**

It :
+ [x] Move some collections classes to `collections.abc` module (was deprecated since 3.3, and removed in 3.10)
https://docs.python.org/3.9/library/collections.html
+ [x] Adds CI from **3.7** to **3.10**


Regards,